### PR TITLE
Fixing #3: Do not randomly remove imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "nyc": "^8.3.0"
   },
   "peerDependencies": {
-    "eslint": "2.x - 3.x"
+    "eslint": "2.x - 4.x"
   },
   "dependencies": {
     "builtin-modules": "^1.1.1",

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -77,21 +77,15 @@ function fixOutOfOrder(context, firstNode, secondNode, order) {
     context.report({
       node: secondNode.node,
       message: msg(),
-      fix: fixer => fixer.insertTextBefore(firstRoot.node, newCode)
+      fix: fixer => [fixer.insertTextBefore(firstRoot.node, newCode + "\n"), fixer.remove(secondRoot.node)]
     });
   } else if (order === 'after') {
     context.report({
       node: secondNode.node,
       message: msg(),
-      fix: fixer => fixer.insertTextAfter(firstRoot.node, newCode)
+      fix: fixer => [fixer.insertTextAfter(firstRoot.node, "\n" + newCode), fixer.remove(secondRoot.node)]
     });
   }
-
-  context.report({
-    node: secondNode.node,
-    message: msg(),
-    fix: fixer => fixer.remove(secondRoot.node)
-  });
 }
 
 function reportOutOfOrder(context, imported, outOfOrder, order) {


### PR DESCRIPTION
Imports are nolonger getting removed.

But 2 culprits still exists:
1. when there is non-import-code between 2 import it gets removed
2. additional empty newlines are left-behind on original import location. fortunately other fixers may remove them :)